### PR TITLE
Also fetch the .map file referenced by the .min.js file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,18 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>download-min-js-map</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>download-single</goal>
+                        </goals>
+                        <configuration>
+                            <url>${upstream.url}/js</url>
+                            <fromFile>jquery.terminal-${upstream.version}.min.js.map</fromFile>
+                            <toFile>${destDir}/jquery.terminal.min.js.map</toFile>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>download-css</id>
                         <phase>process-resources</phase>
                         <goals>


### PR DESCRIPTION
We use the 2.34.0 version that you made for us, however, it results in a 404 in the console logs because that map file isn't bundled, and also, debugging is difficult. This change should be pretty straightforward but can you easily overwrite the already released artifact with a new one? That is obviously what we'd like if possible. Thanks!